### PR TITLE
does not run table_list command

### DIFF
--- a/goroo.go
+++ b/goroo.go
@@ -9,7 +9,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"strings"
 )
 
 const (
@@ -267,11 +266,12 @@ func (client *GroongaClient) Call(command string, params map[string]string) (res
 }
 
 func (client *GroongaClient) setResult(body []byte) (result GroongaResult, err error) {
-	result.RawData = fmt.Sprintf("%s", body)
+	result.RawData =string(body)
 
 	var data interface{}
-	dec := json.NewDecoder(strings.NewReader(result.RawData))
-	dec.Decode(&data)
+	if err := json.Unmarshal(body, &data); err != nil {
+		return result, err
+	}
 
 	if client.Protocol == "http" {
 		grnInfo := data.([]interface{})


### PR DESCRIPTION
引数を使わないコマンド(ex. table_list)でコマンドが実行されずに終了する問題を修正